### PR TITLE
모집 인원 조정, 내가 참여한 모집 일정 조회  API 생성

### DIFF
--- a/src/main/java/io/cuki/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/io/cuki/domain/participation/controller/ParticipationController.java
@@ -1,14 +1,17 @@
 package io.cuki.domain.participation.controller;
 
 
+import io.cuki.domain.member.exception.MemberNotMatchException;
 import io.cuki.domain.participation.dto.*;
 import io.cuki.global.common.response.ApiResponse;
 import io.cuki.domain.participation.service.ParticipationService;
+import io.cuki.global.util.SecurityUtil;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 import java.util.Set;
 
 
@@ -26,6 +29,25 @@ public class ParticipationController {
         log.debug("참여 요청 = {}", requestDto);
         // try-catch 로 ErrorResponse 응답 할 때 제네릭 타입 반환형이 ok 응답 반환형과 맞지 않는 상황에 어떻게 할 것인가?
         return ApiResponse.ok(participationService.createParticipation(requestDto));
+    }
+
+    @ApiOperation(value = "내가 참여한 게시물 전체 조회")
+    @GetMapping("/members/{memberId}/participation")
+    public ApiResponse<List<ParticipationResponseDto>> getMyParticipation(@PathVariable Long memberId) {
+        if (SecurityUtil.getCurrentMemberId().equals(memberId)) {
+            return ApiResponse.ok(participationService.getMyParticipation(memberId));
+        }
+
+        throw new MemberNotMatchException("파라미터 member id: " + memberId + " 와 로그인 한 유저의 member id:"+ SecurityUtil.getCurrentMemberId()+ " 가 일치 하지 않습니다.");
+    }
+
+    @ApiOperation(value = "내가 참여한 게시물 상세 조회")
+    @GetMapping("/members/{memberId}/participation/{participationId}")
+    public ApiResponse<ParticipationResponseDto> getOneParticipation(@PathVariable Long memberId) {
+        if (!SecurityUtil.getCurrentMemberId().equals(memberId)) {
+            throw new MemberNotMatchException("파라미터 member id: " + memberId + " 와 로그인 한 유저의 member id:"+ SecurityUtil.getCurrentMemberId()+ " 가 일치 하지 않습니다.");
+        }
+        return ApiResponse.ok(participationService.getOneParticipation(memberId));
     }
 
     @ApiOperation(value = "참여 요청한 대기자 리스트 조회", notes = "대기자에 대한 정보 - nickname 보여주기, 아래 API만 살리면 어떨까?")

--- a/src/main/java/io/cuki/domain/participation/dto/OneParticipationResponseDto.java
+++ b/src/main/java/io/cuki/domain/participation/dto/OneParticipationResponseDto.java
@@ -1,0 +1,6 @@
+package io.cuki.domain.participation.dto;
+
+public class OneParticipationResponseDto {
+
+
+}

--- a/src/main/java/io/cuki/domain/participation/dto/ParticipationResponseDto.java
+++ b/src/main/java/io/cuki/domain/participation/dto/ParticipationResponseDto.java
@@ -1,0 +1,52 @@
+package io.cuki.domain.participation.dto;
+
+import io.cuki.domain.participation.entity.Participation;
+import io.cuki.domain.schedule.entity.ScheduleStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class ParticipationResponseDto implements Comparable<ParticipationResponseDto> {
+
+    private Long scheduleId;
+
+    private Long participationId;
+
+    private String title;
+
+    private String nickname;
+
+    private LocalDateTime startDateTime;
+
+    private LocalDateTime endDateTime;
+
+    private ScheduleStatus status;
+
+    public static ParticipationResponseDto of(Participation participation) {
+        return ParticipationResponseDto.builder()
+                .scheduleId(participation.getSchedule().getId())
+                .participationId(participation.getId())
+                .title(participation.getSchedule().getTitle())
+                .nickname(participation.getSchedule().getMember().getNickname())
+                .startDateTime(participation.getSchedule().getDateTime().getStartDateTime())
+                .endDateTime(participation.getSchedule().getDateTime().getEndDateTime())
+                .status(participation.getSchedule().getStatus())
+                .build();
+    }
+
+
+    @Override
+    public int compareTo(ParticipationResponseDto o) {
+        final LocalDateTime now = LocalDateTime.now();
+        final long dDays = Duration.between(now, getStartDateTime()).toDays();
+        final long targetDdays = Duration.between(now, o.getStartDateTime()).toDays();
+
+        return Long.compare(dDays, targetDdays);
+    }
+}

--- a/src/main/java/io/cuki/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/io/cuki/domain/participation/repository/ParticipationRepository.java
@@ -15,6 +15,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     List<Participation> findBySchedule(Schedule schedule);
 
+    List<Participation> findByMemberId(Long memberId);
+
     List<Participation> findByScheduleId(Long scheduleId);
 
     Set<Participation> findByScheduleIdAndResult(Long scheduleId, PermissionResult result);

--- a/src/main/java/io/cuki/domain/participation/service/ParticipationService.java
+++ b/src/main/java/io/cuki/domain/participation/service/ParticipationService.java
@@ -15,9 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 
 @Slf4j
@@ -131,6 +129,14 @@ public class ParticipationService {
         throw new IllegalAccessException("모집인원 초과 || 참여 신청 결정은 한 번만 할 수 있습니다.");
     }
 
+    // 내가 참여한 게시글 상세 조회
+    public ParticipationResponseDto getOneParticipation(Long memberId) {
+        final List<Participation> participationList = participationRepository.findByMemberId(memberId);
+        // 게시글 정보, 내 신청 정보
+
+        return null;
+    }
+
     public Set<ParticipantInfoResponseDto> getParticipantList(Long scheduleId) {
         // 확정자 명단 조회는 누구나 조회 가능한지?
         Set<ParticipantInfoResponseDto> members = new HashSet<>();
@@ -152,5 +158,22 @@ public class ParticipationService {
             log.debug("스케쥴 상태 = {}", schedule.getStatus());
             throw new IllegalArgumentException("이미 모집이 마감된 스케쥴 입니다.");
         }
+    }
+
+    @Transactional
+    public List<ParticipationResponseDto> getMyParticipation(Long memberId) {
+        List<ParticipationResponseDto> responseDtoList = new ArrayList<>();
+        // ParticipationResponseDto
+        // OneParticipationResponseDto
+
+        participationRepository.findByMemberId(memberId)
+                .forEach(participation -> responseDtoList.add(ParticipationResponseDto.of(participation)));
+
+        Collections.sort(responseDtoList);
+        for (ParticipationResponseDto my : responseDtoList) {
+            log.debug("response sort = {}", my.getStartDateTime());
+        }
+
+        return responseDtoList;
     }
 }

--- a/src/main/java/io/cuki/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/io/cuki/domain/schedule/controller/ScheduleController.java
@@ -3,6 +3,7 @@ package io.cuki.domain.schedule.controller;
 import io.cuki.domain.schedule.service.SchedulesService;
 import io.cuki.global.common.response.ApiResponse;
 import io.cuki.domain.schedule.dto.*;
+import io.cuki.global.util.SecurityUtil;
 import io.cuki.global.util.SliceCustom;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -43,7 +44,7 @@ public class ScheduleController {
     }
 
 
-    @ApiOperation(value = "내 게시물 조회")
+    @ApiOperation(value = "내가 작성한 게시물 전체 조회")
     @GetMapping("/members/{memberId}/schedules")
     public ApiResponse<List<MyScheduleResponseDto>> getMySchedule(@PathVariable Long memberId) {
         return ApiResponse.ok(schedulesService.getMySchedule(memberId));

--- a/src/main/java/io/cuki/domain/schedule/dto/ScheduleRegistrationRequestDto.java
+++ b/src/main/java/io/cuki/domain/schedule/dto/ScheduleRegistrationRequestDto.java
@@ -35,7 +35,7 @@ public class ScheduleRegistrationRequestDto {
                 .title(title)
                 .member(member)
                 .dateTime(new SchedulePeriod(startDateTime, endDateTime))
-                .fixedNumberOfPeople(fixedNumberOfPeople)
+                .fixedNumberOfPeople((fixedNumberOfPeople+ONESELF))
                 .currentNumberOfPeople(ONESELF)
                 .location(new Location(place))
                 .details(details)

--- a/src/main/java/io/cuki/domain/schedule/service/SchedulesService.java
+++ b/src/main/java/io/cuki/domain/schedule/service/SchedulesService.java
@@ -56,6 +56,7 @@ public class SchedulesService {
         final Schedule schedule = memberRepository.findById(SecurityUtil.getCurrentMemberId())
                 .map(registrationRequestDto::toEntity)
                 .orElseThrow(MemberNotFoundException::new);
+        log.debug("모집 인원(작성자 포함) = {}", schedule.getFixedNumberOfPeople());
 
         return new IdResponseDto(schedulesRepository.save(schedule).getId());
     }
@@ -121,7 +122,6 @@ public class SchedulesService {
         schedule.updateStatusToDone();
         return IdAndStatusResponseDto.of(schedule);
     }
-
 
 
 }


### PR DESCRIPTION
모집 인원 조정
클라이언트:  모집 인원 1명 선택 -> 서버: logic: 총 모집 인원 2명, 모집 확정자 1명 

내가 작성한 게시글  조회 / 내가 참여신청한 게시글 조회 분리 생성
